### PR TITLE
Use updated beta version of ioc-adaravis

### DIFF
--- a/services/bl48p-ea-dcam-01/values.yaml
+++ b/services/bl48p-ea-dcam-01/values.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/5.5.0/ioc-instance.schema.json#/$defs/service
 
 ioc-instance:
-  image: ghcr.io/epics-containers/ioc-adaravis-runtime:2026.4.3
+  image: ghcr.io/epics-containers/ioc-adaravis-runtime:r2-3-ec1.beta.25
 
   dataVolume:
     pvc: false

--- a/services/bl48p-ea-dcam-02/values.yaml
+++ b/services/bl48p-ea-dcam-02/values.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/5.5.0/ioc-instance.schema.json#/$defs/service
 
 ioc-instance:
-  image: ghcr.io/epics-containers/ioc-adaravis-runtime:2026.4.3
+  image: ghcr.io/epics-containers/ioc-adaravis-runtime:r2-3-ec1.beta.25
 
   dataVolume:
     pvc: false


### PR DESCRIPTION
With service template v5.7.1, ioc-adaravis v2026.4.3 leads to a recurring ioc pod error related to 'makePvi.py' (file /tmp/${instance_id}-genicam.xml not found) despite the pod starting up cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the IOC runtime image to version `r2-3-ec1.beta.25` for both deployed services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->